### PR TITLE
Update dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Then, on the next page you need to download two packages
 
 Then unpack both archives content together into one dir.
 Then create subdirs /network/admin and put there your tnsnames.ors file.
-Windows users should then add this dir to PATH system variable
+Windows users might have to set 
+- PATH to the folder with sqlplus executable
+- ORACLE_HOME to your Oracle folder 
+- TNS_ADMIN to the folder containing tnsnames.ora file 
 
 \* - i.e. Windows users have to install MS Visual Studio in order to get oracledb work
 
@@ -26,5 +29,7 @@ sqlplus(sql, connProps, function(err, rows){
 	else {
 		console.log(rows)
 	}
-});
+  }, 
+  false, // optional parameter: debug=false (default) activates debug messages on console
+  5000); // optional parameter: timeout=10000 (default) for sqlplus process in milliseconds
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Then, on the next page you need to download two packages
 - Instant Client Package - SQL*Plus
 
 Then unpack both archives content together into one dir.
-Then create subdirs /network/admin and put there your tnsnames.ors file.
+Then create subdirs /network/admin and put there your tnsnames.ora file.
 Windows users might have to set 
 - PATH to the folder with sqlplus executable
 - ORACLE_HOME to your Oracle folder 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const spawn = require('child_process').spawn
-const csvparse = require('csv-parse')
+const csvparse = require('csv-parse').parse
 const isWin = process.platform === 'win32'
 const isMac = process.platform === 'darwin'
 const isLinux = process.platform === 'linux'

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = function (sql, connProps, callback, bDebug, maxTimeout) {
       const colNamesArray = output.split(/\r\n?|\n/, 2)[1].split('"').join('').split(',')
       const csvparseOpt = {
         columns: colNamesArray,
+        relax_column_count: true,
         skip_lines_with_empty_values: true,
         from: 2 // first line is blank, second is headings
       }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "author": "mankey-ru",
   "license": "ISC",
   "dependencies": {
-    "csv-parse": "~1.2.0",
-    "fix-path": "^2.1.0",
-    "tmp": "~0.1.0"
+    "csv-parse": "~5.0.4",
+    "fix-path": "^4.0.0",
+    "tmp": "~0.2.1"
   }
 }


### PR DESCRIPTION
Updated dependencies for all npm modules. 
`csv-parse` works after adjustment of the require statment - so we can keep the csv-parse callback API and no additional code change is required. 
See: https://csv.js.org/parse/api/callback/ 

I think https://github.com/mankey-ru/node-sqlplus/pull/1 should be rejected because my PR includes the csv-parse update.

README changes:
Added clarification about Windows-Setup and new timeout parameter. 

 